### PR TITLE
fix: fix FFI deprecation warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,15 +22,11 @@ jobs:
       - name: Setup PHP env
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
           extensions: ffi
           tools: composer
         env:
           fail-fast: true
-      - name: Setup Composer
-        run: |
-          composer install
-          composer require --dev phpunit/phpunit ^10
       - name: Test PHP SDK
         run: |
-          ./vendor/bin/phpunit ./tests
+          make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: test
+
+prepare:
+	composer install
+
+test: prepare
+	php vendor/bin/phpunit ./tests --display-deprecations

--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ prepare:
 	composer install
 
 test: prepare
-	php vendor/bin/phpunit ./tests --display-deprecations
+	php vendor/bin/phpunit ./tests --display-deprecations --display-warnings

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,6 @@
   "scripts": {},
   "scripts-descriptions": {},
   "require-dev": {
-    "phpunit/phpunit": "^10.4"
+    "phpunit/phpunit": "^10"
   }
 }

--- a/src/LibExtism.php
+++ b/src/LibExtism.php
@@ -25,7 +25,7 @@ class LibExtism
         foreach ($directories as $directory) {
             $fullPath = $directory . DIRECTORY_SEPARATOR . $name;
 
-            if (file_exists($fullPath)) {
+            if (file_exists($fullPath)) {               
                 return FFI::cdef(
                     file_get_contents(__DIR__ . "/extism.h"),
                     $fullPath
@@ -119,7 +119,7 @@ class LibExtism
             return null;
         }
 
-        $str = FFI::new($type . "[" . \strlen($string) . "]", true);
+        $str = $this->extism->new($type . "[" . \strlen($string) . "]", true);
         FFI::memcpy($str, $string, \strlen($string));
         return $str;
     }

--- a/src/LibExtism.php
+++ b/src/LibExtism.php
@@ -25,7 +25,7 @@ class LibExtism
         foreach ($directories as $directory) {
             $fullPath = $directory . DIRECTORY_SEPARATOR . $name;
 
-            if (file_exists($fullPath)) {               
+            if (file_exists($fullPath)) {
                 return FFI::cdef(
                     file_get_contents(__DIR__ . "/extism.h"),
                     $fullPath

--- a/src/LibExtism.php
+++ b/src/LibExtism.php
@@ -2,11 +2,11 @@
 
 class LibExtism
 {
-    private FFI $extism;
+    public FFI $ffi;
 
     public function __construct() {
         $name = LibExtism::soname();
-        $this->extism = LibExtism::findSo($name);
+        $this->ffi = LibExtism::findSo($name);
     }
 
     function findSo(string $name): FFI {
@@ -56,53 +56,53 @@ class LibExtism
     {
         $ptr = $this->owned("uint8_t", $wasm);
         $wasi = $with_wasi ? 1 : 0;
-        $pluginPtr = $this->extism->extism_plugin_new($ptr, $wasm_size, null, $n_functions, $wasi, $errmsg);
+        $pluginPtr = $this->ffi->extism_plugin_new($ptr, $wasm_size, null, $n_functions, $wasi, $errmsg);
 
-        return $this->extism->cast("ExtismPlugin*", $pluginPtr);
+        return $this->ffi->cast("ExtismPlugin*", $pluginPtr);
     }
 
     function extism_plugin_new_error_free(FFI\CData $ptr): void {
-        $this->extism->extism_plugin_new_error_free($ptr);
+        $this->ffi->extism_plugin_new_error_free($ptr);
     }
 
     function extism_plugin_function_exists(FFI\CData $plugin, string $func_name): bool
     {
-        return $this->extism->extism_plugin_function_exists($plugin, $func_name);
+        return $this->ffi->extism_plugin_function_exists($plugin, $func_name);
     }
 
     function extism_version(): string
     {
-        return $this->extism->extism_version();
+        return $this->ffi->extism_version();
     }
 
     function extism_plugin_call(FFI\CData $plugin, string $func_name, string $data, int $data_len): int
     {
         $dataPtr = $this->owned("uint8_t", $data);
-        return $this->extism->extism_plugin_call($plugin, $func_name, $dataPtr, $data_len);
+        return $this->ffi->extism_plugin_call($plugin, $func_name, $dataPtr, $data_len);
     }
 
     function extism_error(FFI\CData $plugin): ?string
     {
-        return $this->extism->extism_error($plugin);
+        return $this->ffi->extism_error($plugin);
     }
 
     function extism_plugin_error(FFI\CData $plugin): ?string
     {
-        return $this->extism->extism_plugin_error($plugin);
+        return $this->ffi->extism_plugin_error($plugin);
     }
 
     function extism_plugin_output_data(FFI\CData $plugin): string
     {
-        $length = $this->extism->extism_plugin_output_length($plugin);
+        $length = $this->ffi->extism_plugin_output_length($plugin);
 
-        $ptr = $this->extism->extism_plugin_output_data($plugin);
+        $ptr = $this->ffi->extism_plugin_output_data($plugin);
 
         return FFI::string($ptr, $length);
     }
 
     function extism_plugin_free(FFI\CData $plugin): void
     {
-        $this->extism->extism_plugin_free($plugin);
+        $this->ffi->extism_plugin_free($plugin);
     }
 
     function extism_log_file(string $filename, string $log_level): void
@@ -110,7 +110,7 @@ class LibExtism
         $filenamePtr = $this->ownedZero($filename);
         $log_levelPtr = $this->ownedZero($log_level);
 
-        $this->extism->extism_log_file($filenamePtr, $log_levelPtr);
+        $this->ffi->extism_log_file($filenamePtr, $log_levelPtr);
     }
 
     function owned(string $type, string $string): FFI\CData|null
@@ -119,7 +119,7 @@ class LibExtism
             return null;
         }
 
-        $str = $this->extism->new($type . "[" . \strlen($string) . "]", true);
+        $str = $this->ffi->new($type . "[" . \strlen($string) . "]", true);
         FFI::memcpy($str, $string, \strlen($string));
         return $str;
     }

--- a/src/LibExtism.php
+++ b/src/LibExtism.php
@@ -6,14 +6,14 @@ class LibExtism
 
     public function __construct() {
         $name = LibExtism::soname();
-        $this->extism = self::findSo($name);
+        $this->extism = LibExtism::findSo($name);
     }
 
     function findSo(string $name): FFI {
         $platform = php_uname("s");
 
         $directories = [];
-        if (self::startsWith($platform, "windows")) {
+        if (LibExtism::startsWith($platform, "windows")) {
             $path = getenv('PATH');
             $directories = explode(PATH_SEPARATOR, $path);
 
@@ -126,7 +126,7 @@ class LibExtism
 
     function ownedZero(string $string): FFI\CData|null
     {
-        return self::owned("char", "$string\0");
+        return $this->owned("char", "$string\0");
     }
 
     function startsWith($haystack, $needle) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -49,7 +49,7 @@ class Plugin
             return;
         }
 
-        $errPtr = \FFI::new(\FFI::type("char*"));
+        $errPtr = $lib->ffi->new($lib->ffi->type("char*"));
         $handle = $this->lib->extism_plugin_new($data, strlen($data), [], 0, $with_wasi, \FFI::addr($errPtr));
 
         if (\FFI::isNull($errPtr) == false) {


### PR DESCRIPTION
Related to #8 

> Calling [FFI::cast()](https://www.php.net/manual/en/ffi.cast.php), [FFI::new()](https://www.php.net/manual/en/ffi.new.php), and [FFI::type()](https://www.php.net/manual/en/ffi.type.php) statically is now deprecated.

-- [PHP 8.3 Migration docs](https://www.php.net/manual/en/migration83.deprecated.php)

We are only calling FFI::new statically (versus calling it on an instance of FFI) in a couple of places, this PR fixes that. I have also added `--display-deprecations` to phpunit and it shows no warnings now