### PR TITLE
fix: Remove PHP 8.0 syntax to maintain PHP 7.4 compatibility

### DIFF
--- a/src/LibExtism.php
+++ b/src/LibExtism.php
@@ -72,7 +72,7 @@ class LibExtism
         return $this->ffi->extism_current_plugin_memory_length($plugin, $offset);
     }
 
-    function extism_plugin_new(string $wasm, int $wasm_size, FFI\CData $functions, int $n_functions, bool $with_wasi, ?FFI\CData $errmsg): FFI\CData|null
+    function extism_plugin_new(string $wasm, int $wasm_size, FFI\CData $functions, int $n_functions, bool $with_wasi, ?FFI\CData $errmsg): ?FFI\CData
     {
         $ptr = $this->owned("uint8_t", $wasm);
         $wasi = $with_wasi ? 1 : 0;
@@ -154,7 +154,7 @@ class LibExtism
         $this->ffi->extism_function_set_namespace($handle, $namePtr);
     }
 
-    function toCArray(array $array, string $type): FFI\CData | null
+    function toCArray(array $array, string $type): ?FFI\CData
     {
         if (count($array) == 0) {
             return $this->ffi->new($type . "*");
@@ -168,7 +168,7 @@ class LibExtism
         return $cArray;
     }
 
-    function owned(string $type, string $string): FFI\CData|null
+    function owned(string $type, string $string): ?FFI\CData
     {
         if (strlen($string) == 0) {
             return null;
@@ -179,7 +179,7 @@ class LibExtism
         return $str;
     }
 
-    function ownedZero(string $string): FFI\CData|null
+    function ownedZero(string $string): ?FFI\CData
     {
         return $this->owned("char", "$string\0");
     }


### PR DESCRIPTION
Union return types are not supported in PHP 7.4. Thankfully, `T|null` is equivalent to `?T`. See below:
https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.nullable