### PR TITLE
fix: throw exception when extism_error() returns a non-null string

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -43,7 +43,7 @@ class Plugin
 
         $this->lib = $lib;
 
-        $functionHandles = array_map(function($function) {
+        $functionHandles = array_map(function ($function) {
             return $function->handle;
         }, $functions);
 
@@ -97,16 +97,14 @@ class Plugin
      * 
      * @return string Output buffer
      */
-    public function call(string $name, string $input = null) : string
+    public function call(string $name, string $input = null): string
     {
         $rc = $this->lib->extism_plugin_call($this->handle, $name, $input, strlen($input));
 
-        if ($rc != 0) {
-            $msg = "code = " . $rc;
-            $err = $this->lib->extism_error($this->handle);
-            if ($err) {
-                $msg = $msg . ", error = " . $err;
-            }
+        $msg = "code = " . $rc;
+        $err = $this->lib->extism_error($this->handle);
+        if ($err) {
+            $msg = $msg . ", error = " . $err;
             throw new \Exception("Extism: call to '" . $name . "' failed with " . $msg);
         }
 
@@ -120,16 +118,16 @@ class Plugin
      * @param string $level Minimum log level. Valid values are: `trace`, `debug`, `info`, `warn`, `error`
      * or more complex filter like `extism=trace,cranelift=debug`.
      */
-    public static function setLogFile(string $filename, string $level) : void
+    public static function setLogFile(string $filename, string $level): void
     {
         $lib = new \LibExtism();
         $lib->extism_log_file($filename, $level);
     }
 
     /**
-    * Get the Extism version string
-    * @return string
-    */
+     * Get the Extism version string
+     * @return string
+     */
     public static function version()
     {
         $lib = new \LibExtism();

--- a/src/extism.h
+++ b/src/extism.h
@@ -10,7 +10,7 @@
 #define EXTISM_SUCCESS 0
 
 /** An alias for I64 to signify an Extism pointer */
-#define PTR I64
+#define EXTISM_PTR ExtismValType_I64
 
 
 /**
@@ -20,31 +20,31 @@ typedef enum {
   /**
    * Signed 32 bit integer.
    */
-  I32,
+  ExtismValType_I32,
   /**
    * Signed 64 bit integer.
    */
-  I64,
+  ExtismValType_I64,
   /**
    * Floating point 32 bit integer.
    */
-  F32,
+  ExtismValType_F32,
   /**
    * Floating point 64 bit integer.
    */
-  F64,
+  ExtismValType_F64,
   /**
    * A 128 bit number.
    */
-  V128,
+  ExtismValType_V128,
   /**
    * A reference to a Wasm function.
    */
-  FuncRef,
+  ExtismValType_FuncRef,
   /**
    * A reference to opaque data in the Wasm instance.
    */
-  ExternRef,
+  ExtismValType_ExternRef,
 } ExtismValType;
 
 /**
@@ -109,6 +109,12 @@ typedef void (*ExtismLogDrainFunctionType)(const char *data, ExtismSize size);
  * Get a plugin's ID, the returned bytes are a 16 byte buffer that represent a UUIDv4
  */
 const uint8_t *extism_plugin_id(ExtismPlugin *plugin);
+
+/**
+ * Get the current plugin's associated host context data. Returns null if call was made without
+ * host context.
+ */
+void *extism_current_plugin_host_context(ExtismCurrentPlugin *plugin);
 
 /**
  * Returns a pointer to the memory of the currently running plugin
@@ -227,6 +233,20 @@ int32_t extism_plugin_call(ExtismPlugin *plugin,
                            const char *func_name,
                            const uint8_t *data,
                            ExtismSize data_len);
+
+/**
+ * Call a function with host context.
+ *
+ * `func_name`: is the function to call
+ * `data`: is the input data
+ * `data_len`: is the length of `data`
+ * `host_context`: a pointer to context data that will be available in host functions
+ */
+int32_t extism_plugin_call_with_host_context(ExtismPlugin *plugin,
+                                             const char *func_name,
+                                             const uint8_t *data,
+                                             ExtismSize data_len,
+                                             void *host_context);
 
 /**
  * Get the error associated with a `Plugin`


### PR DESCRIPTION
This PR fixes the cases where the plugin panics (so extism_error is not null) but extism_call_function returns 0

I also updated extism.h