### PR TITLE
fix: Host Functions of PHP 7.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        php: ['8.3']
+        php: ['8.3', '7.4']
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ prepare:
 	composer install
 
 test: prepare
-	php vendor/bin/phpunit ./tests --display-deprecations --display-warnings
+	php vendor/bin/phpunit ./tests

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,6 @@
   "scripts": {},
   "scripts-descriptions": {},
   "require-dev": {
-    "phpunit/phpunit": "^10"
+    "phpunit/phpunit": "^9"
   }
 }

--- a/src/HostFunction.php
+++ b/src/HostFunction.php
@@ -15,6 +15,16 @@ class ExtismValType
     public const V128 = 4;
     public const FUNC_REF = 5;
     public const EXTERN_REF = 6;
+
+    public const VAL_TYPE_MAP = [
+        0 => 'I32',
+        1 => 'I64',
+        2 => 'F32',
+        3 => 'F64',
+        4 => 'V128',
+        5 => 'FUNC_REF',
+        6 => 'EXTERN_REF',
+    ];
 }
 
 class HostFunction
@@ -52,13 +62,15 @@ class HostFunction
         $inputs = [];
 
         for ($i = 0; $i < count($inputTypes); $i++) {
-            $inputs[$i] = $this->lib->ffi->cast("ExtismValType", $inputTypes[$i]);
+            $enum = ExtismValType::VAL_TYPE_MAP[$inputTypes[$i]];
+            $inputs[$i] = $this->lib->ffi->$enum;
         }
 
         $outputs = [];
 
         for ($i = 0; $i < count($outputTypes); $i++) {
-            $outputs[$i] = $this->lib->ffi->cast("ExtismValType", $outputTypes[$i]);
+            $enum = ExtismValType::VAL_TYPE_MAP[$outputTypes[$i]];
+            $outputs[$i] = $this->lib->ffi->$enum;
         }
 
         $func = function ($handle, $inputs, $n_inputs, $outputs, $n_outputs, $data) use ($callback, $lib, $arguments, $offset) {

--- a/src/HostFunction.php
+++ b/src/HostFunction.php
@@ -17,13 +17,13 @@ class ExtismValType
     public const EXTERN_REF = 6;
 
     public const VAL_TYPE_MAP = [
-        0 => 'I32',
-        1 => 'I64',
-        2 => 'F32',
-        3 => 'F64',
-        4 => 'V128',
-        5 => 'FUNC_REF',
-        6 => 'EXTERN_REF',
+        0 => 'ExtismValType_I32',
+        1 => 'ExtismValType_I64',
+        2 => 'ExtismValType_F32',
+        3 => 'ExtismValType_F64',
+        4 => 'ExtismValType_V128',
+        5 => 'ExtismValType_Func_Ref',
+        6 => 'ExtismValType_Extern_Ref',
     ];
 }
 


### PR DESCRIPTION
Fixes issue https://github.com/extism/php-sdk/issues/22 that causes host functions with arguments to not work on PHP 7.4.
See issue for context.

